### PR TITLE
try importing hpb from prody

### DIFF
--- a/prody/proteins/interactions.py
+++ b/prody/proteins/interactions.py
@@ -172,9 +172,19 @@ def calcHydrophobicOverlapingAreas(atoms, **kwargs):
     :type cumulative_values: 'pairs' or 'single_residues'
     """
     
-    try:
-        import hpb
+    imported_hpb = False
 
+    try:
+        import prody.proteins.hpb as hpb
+        imported_hpb = True
+    except ImportError:
+        try:
+            import hpb
+            imported_hpb = True
+        except ImportError:
+            LOGGER.info('Please provide hpb.so file into the directory.')
+
+    if imported_hpb:
         selection = kwargs.pop('selection', 'protein and noh')
         hpb_cutoff = kwargs.pop('hpb_cutoff', 0.0)
         cumulative_values = kwargs.pop('cumulative_values', None)
@@ -214,9 +224,6 @@ def calcHydrophobicOverlapingAreas(atoms, **kwargs):
                 sums[k] = sums.get(k, 0) + w
             return sums
     
-    except: 
-        LOGGER.info('Please provide hpb.so file into the directory.')
-    
 
 def calcSASA(atoms, **kwargs):
     """Provide information about solvent accessible surface area (SASA) based on 
@@ -238,9 +245,19 @@ def calcSASA(atoms, **kwargs):
     :type resnames: bool    
     """
     
+    imported_hpb = False
+
     try:
-        import hpb
-        
+        import prody.proteins.hpb as hpb
+        imported_hpb = True
+    except ImportError:
+        try:
+            import hpb
+            imported_hpb = True
+        except ImportError:
+            LOGGER.info('Please provide hpb.so file into the directory.')
+
+    if imported_hpb:
         selection = kwargs.pop('selection', 'protein and noh')
         resnames = kwargs.pop('resnames', False)
         sasa_cutoff = kwargs.pop('sasa_cutoff', 0.0)
@@ -264,9 +281,6 @@ def calcSASA(atoms, **kwargs):
             return output_final
         else:
             return [ float(i[-1]) for i in output_final ]
-
-    except: 
-        LOGGER.info('Please provide hpb.so file into the directory.')
 
 def calcVolume(atoms, **kwargs):
     """Provide information about volume for each residue/molecule/chain
@@ -294,9 +308,19 @@ def calcVolume(atoms, **kwargs):
     :type resnames: bool
     """
     
-    try:
-        import hpb
+    imported_hpb = False
 
+    try:
+        import prody.proteins.hpb as hpb
+        imported_hpb = True
+    except ImportError:
+        try:
+            import hpb
+            imported_hpb = True
+        except ImportError:
+            LOGGER.info('Please provide hpb.so file into the directory.')
+
+    if imported_hpb:
         selection = kwargs.pop('selection', 'protein and noh')
         resnames = kwargs.pop('resnames', False)
         volume_cutoff = kwargs.pop('volume_cutoff', 0.0)
@@ -325,9 +349,6 @@ def calcVolume(atoms, **kwargs):
             
         else:
             return sum( [float(i[-1]) for i in output_final] )
-
-    except: 
-        LOGGER.info('Please provide hpb.so file into the directory.')
 
 
 def calcHydrogenBonds(atoms, **kwargs):


### PR DESCRIPTION
This currently works on my system (WSL2 linux with `python setup.py build_ext --inplace --force` run some time ago and maybe some attempts at installing hpb done some time ago too but I don't remember what or when):
```
(scipion3) jkrieger@whipple ~/software/scipion3/software/em/ProDy/test_interactions (interactions_jmk) $ ipython
Python 3.8.13 (default, Mar 28 2022, 11:38:47) 
Type 'copyright', 'credits' or 'license' for more information
IPython 8.3.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from prody import *

In [2]: atoms = parsePDB("5kqm_all_sci.pdb")
@> 19321 atoms and 1 coordinate set(s) were parsed in 0.13s.

In [3]: areas = calcHydrophobicOverlapingAreas(atoms)
@> Hydrophobic Overlaping Areas are computed.

In [4]: len(areas)
Out[4]: 2391

In [5]: areas[:5]
Out[5]: 
[['THR5', 'OG1_8', 'P', 'TRP39', 'N_537', 'P', 2.4253310536589834],
 ['THR5', 'OG1_8', 'P', 'TRP39', 'CA_539', 'P', 0.21714493110559124],
 ['THR5', 'OG1_8', 'P', 'TRP39', 'C_559', 'P', 2.258631418331087],
 ['LYS6', 'CB_20', 'P', 'TRP39', 'CE2_549', 'P', 3.251864894241113],
 ['LYS6', 'CB_20', 'P', 'TRP39', 'CD2_550', 'P', 2.3094365745667957]]

In [6]: sasa = calcSASA(atoms)
@> Solvent Accessible Surface Area (SASA) is computed.

In [7]: len(sasa)
Out[7]: 153

In [8]: sasa[:5]
Out[8]: [145.56206554677985, 106.24806001305733, 6.585237947983879, 0.0, 0.0]

In [9]: vol = calcVolume(atoms)
@> Volume is computed.

In [10]: vol
Out[10]: 28780.02202547906
```