### PR TITLE
missed import

### DIFF
--- a/prody/proteins/interactions.py
+++ b/prody/proteins/interactions.py
@@ -1128,9 +1128,19 @@ def calcHydrophobic(atoms, **kwargs):
     selection2 = kwargs.get('selection2', None) 
     sel_kwargs = {k: v for k, v in kwargs.items() if k.startswith('selection')}
         
-    try: 
-        import hpb                
-    
+    imported_hpb = False
+
+    try:
+        import prody.proteins.hpb as hpb
+        imported_hpb = True
+    except ImportError:
+        try:
+            import hpb
+            imported_hpb = True
+        except ImportError:
+            LOGGER.info('Please provide hpb.so file into the directory.')
+
+    if imported_hpb:
         Hydrophobic_calculations = sorted(Hydrophobic_calculations, key=lambda x : x[-2])
         Hydrophobic_calculations_final = removeDuplicates(Hydrophobic_calculations)
         Hydrophobic_calculations_final2 = filterInteractions(Hydrophobic_calculations_final, atoms, **sel_kwargs)
@@ -1147,7 +1157,7 @@ def calcHydrophobic(atoms, **kwargs):
         
         return Hydrophobic_calculations_final3
 
-    except:                    
+    else:
         Hydrophobic_calculations = sorted(Hydrophobic_calculations, key=lambda x : x[-1])
         Hydrophobic_calculations_final = removeDuplicates(Hydrophobic_calculations)
         Hydrophobic_calculations_final2 = filterInteractions(Hydrophobic_calculations_final, atoms, **sel_kwargs)


### PR DESCRIPTION
It works now.

Using this version, I get the following:
```
(scipion3) jkrieger@whipple ~/software/scipion3/software/em/ProDy/test_interactions (interactions_jmk) $ ipython
Python 3.8.13 (default, Mar 28 2022, 11:38:47) 
Type 'copyright', 'credits' or 'license' for more information
IPython 8.3.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from prody import *

In [2]: atoms = parsePDB("5kqm_all_sci.pdb")
@> 19321 atoms and 1 coordinate set(s) were parsed in 0.14s.

In [3]: areas = calcHydrophobicOverlapingAreas(atoms)
@> Hydrophobic Overlaping Areas are computed.

In [4]: areas[:5]
Out[4]: 
[['THR5', 'OG1_8', 'P', 'TRP39', 'N_537', 'P', 2.4253310536589834],
 ['THR5', 'OG1_8', 'P', 'TRP39', 'CA_539', 'P', 0.21714493110559124],
 ['THR5', 'OG1_8', 'P', 'TRP39', 'C_559', 'P', 2.258631418331087],
 ['LYS6', 'CB_20', 'P', 'TRP39', 'CE2_549', 'P', 3.251864894241113],
 ['LYS6', 'CB_20', 'P', 'TRP39', 'CD2_550', 'P', 2.3094365745667957]]

In [5]: results = calcHydrophobic(atoms)
@> Hydrophobic Overlaping Areas are computed.
@> Calculating hydrophobic interactions.
@>      TYR87    P       OH_128614s  <--->     ALA156    P       CB_2401     3.0    22.0
@>      MET63    P        CE_89414s  <--->      ALA24    P        CB_298     3.3     5.2
@>      ILE68    P       CG2_97614s  <--->      MET63    P        CE_894     3.3    52.4
@>     TYR142    P       CZ_217114s  <--->     VAL146    P      CG2_2235     3.5    49.7
@>      PHE10    P        CD1_9214s  <--->      ALA22    P        CB_273     3.5    31.2
@>       LYS6    P         CD_2614s  <--->      TRP39    P       CZ2_555     3.5    68.7
@>      VAL30    P       CG1_41114s  <--->      PHE26    P       CE2_336     3.6    21.1
@>     ALA111    P       CB_167714s  <--->      ILE88    P       CD_1307     3.6    21.2
@>      VAL11    P       CG2_11414s  <--->      ILE88    P      CG2_1300     3.6     9.3
@>      VAL41    P       CG2_59514s  <--->      PHE26    P       CD2_334     3.6    16.6
@>     PHE152    P      CE1_233114s  <--->     ALA156    P       CB_2401     3.7    17.5
@>     VAL106    P      CG2_159814s  <--->      LYS79    P       CG_1155     3.7    25.1
@>      ILE77    P       CD_112814s  <--->      LEU99    P      CD2_1480     3.7    12.0
@>      PHE82    P      CD1_120514s  <--->      ILE88    P       CD_1307     3.7    17.6
@>     ILE127    P       CD_194914s  <--->     LEU116    P      CD2_1771     3.7    17.4
@>       VAL8    P        CG1_5514s  <--->      PHE26    P       CE2_336     3.7    12.1
@>      LEU96    P      CD1_142114s  <--->     ILE113    P      CG2_1711     3.7    17.0
@>       LEU9    P        CD2_7814s  <--->      ILE77    P       CD_1128     3.7    15.4
@>      LEU89    P      CD1_132214s  <--->       VAL8    P        CG2_59     3.8    15.9
@>     ILE126    P       CD_193014s  <--->     LEU125    P      CD1_1907     3.8    54.2
@>     VAL141    P      CG1_214914s  <--->     ILE127    P      CG2_1942     3.9    11.5
@>      MET91    P       SD_135314s  <--->     ILE127    P       CD_1949     3.9    35.9
@>      ALA44    P        CB_62814s  <--->       LEU9    P        CD1_74     3.9    15.1
@>      VAL25    P       CG2_31414s  <--->     TYR142    P      CE1_2169     3.9    12.0
@>      ILE21    P       CG2_25614s  <--->      MET63    P        SD_893     4.0    20.8
@>     LEU153    P      CD1_235014s  <--->      TRP39    P       NE1_547     4.0     9.4
@>      PHE85    P       CZ_125314s  <--->       LEU9    P        CD1_74     4.0    32.1
@>      ILE35    P        CD_49114s  <--->      TRP39    P       NE1_547     4.0    26.0
@>      LEU29    P       CD1_39514s  <--->      VAL25    P       CG1_310     4.1    19.7
@>      ALA74    P       CB_106814s  <--->      ILE16    P       CG2_177     4.1     6.7
@>      ARG75    P       CG_108114s  <--->      ALA44    P        CB_628     4.1    36.2
@>      ARG18    P        CG_20814s  <--->     VAL141    P      CG1_2149     4.1    20.3
@>     LYS102    P       CD_153414s  <--->      ILE77    P      CG2_1121     4.1    17.5
@>     TYR119    P      CE1_180514s  <--->      LEU89    P      CD2_1326     4.1    11.6
@>      ARG40    P        CG_56814s  <--->      PHE85    P      CE2_1257     4.3    60.9
@>      LYS28    P        CG_37114s  <--->      ILE68    P        CD_983     4.3    21.8
@>     PHE138    P      CD2_210814s  <--->      ILE21    P        CD_263     4.3     6.6
@>     TYR131    P      CE1_200614s  <--->      ILE16    P        CD_184     4.3     8.9
@>      ARG58    P        CG_82014s  <--->     PHE138    P      CE1_2104     4.5    59.4
@> Number of detected hydrophobic interactions: 39.

In [6]: results[:5]
Out[6]: 
[['TYR87', 'OH_1286', 'P', 'ALA156', 'CB_2401', 'P', 3.0459, 21.959],
 ['MET63', 'CE_894', 'P', 'ALA24', 'CB_298', 'P', 3.3105, 5.1584],
 ['ILE68', 'CG2_976', 'P', 'MET63', 'CE_894', 'P', 3.3306, 52.4165],
 ['TYR142', 'CZ_2171', 'P', 'VAL146', 'CG2_2235', 'P', 3.4815, 49.7427],
 ['PHE10', 'CD1_92', 'P', 'ALA22', 'CB_273', 'P', 3.5334, 31.1973]]
```

Without it, I don't have the last element:
```
(scipion3) jkrieger@whipple ~/software/scipion3/software/em/ProDy/test_interactions (interactions) $ ipython
Python 3.8.13 (default, Mar 28 2022, 11:38:47) 
Type 'copyright', 'credits' or 'license' for more information
IPython 8.3.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from prody import *

In [2]: atoms = parsePDB("5kqm_all_sci.pdb")
@> 19321 atoms and 1 coordinate set(s) were parsed in 0.13s.

In [3]: results = calcHydrophobic(atoms)
@> Please provide hpb.so file into the directory.
@> Calculating hydrophobic interactions.
@>      TYR87    P       OH_1286  <--->     ALA156    P       CB_2401     3.0
@>      MET63    P        CE_894  <--->      ALA24    P        CB_298     3.3
@>      ILE68    P       CG2_976  <--->      MET63    P        CE_894     3.3
@>     TYR142    P       CZ_2171  <--->     VAL146    P      CG2_2235     3.5
@>      ALA22    P        CB_273  <--->      PHE10    P        CD1_92     3.5
@>       LYS6    P         CD_26  <--->      TRP39    P       CZ2_555     3.5
@>      PHE26    P       CE2_336  <--->      VAL30    P       CG1_411     3.6
@>     ALA111    P       CB_1677  <--->      ILE88    P       CD_1307     3.6
@>      VAL11    P       CG2_114  <--->      ILE88    P      CG2_1300     3.6
@>      VAL41    P       CG2_595  <--->      PHE26    P       CD2_334     3.6
@>     PHE152    P      CE1_2331  <--->     ALA156    P       CB_2401     3.7
@>     VAL106    P      CG2_1598  <--->      LYS79    P       CG_1155     3.7
@>      ILE77    P       CD_1128  <--->      LEU99    P      CD2_1480     3.7
@>      PHE82    P      CD1_1205  <--->      ILE88    P       CD_1307     3.7
@>     ILE127    P       CD_1949  <--->     LEU116    P      CD2_1771     3.7
@>       VAL8    P        CG1_55  <--->      PHE26    P       CE2_336     3.7
@>     LEU115    P      CD1_1748  <--->     LEU125    P      CD1_1907     3.7
@>      MET70    P       CE_1014  <--->      MET63    P        CG_890     3.7
@>     ILE113    P      CG2_1711  <--->      LEU96    P      CD1_1421     3.7
@>       LEU9    P        CD2_78  <--->      ILE77    P       CD_1128     3.7
@>      LEU89    P      CD1_1322  <--->       VAL8    P        CG2_59     3.8
@>     ILE126    P       CD_1930  <--->     LEU125    P      CD1_1907     3.8
@>     VAL141    P      CG1_2149  <--->     ILE127    P      CG2_1942     3.9
@>      MET91    P       SD_1353  <--->     ILE127    P       CD_1949     3.9
@>      ALA44    P        CB_628  <--->       LEU9    P        CD1_74     3.9
@>      VAL25    P       CG2_314  <--->     TYR142    P      CE1_2169     3.9
@>      ILE21    P       CG2_256  <--->      MET63    P        SD_893     4.0
@>     LEU153    P      CD1_2350  <--->      TRP39    P       NE1_547     4.0
@>      PHE85    P       CZ_1253  <--->       LEU9    P        CD1_74     4.0
@>      ILE35    P        CD_491  <--->      TRP39    P       NE1_547     4.0
@>      LEU29    P       CD1_395  <--->      VAL25    P       CG1_310     4.1
@>      ILE16    P       CG2_177  <--->      ALA74    P       CB_1068     4.1
@>      ARG75    P       CG_1081  <--->      ALA44    P        CB_628     4.1
@>      ARG18    P        CG_208  <--->     VAL141    P      CG1_2149     4.1
@>     LYS102    P       CD_1534  <--->      ILE77    P      CG2_1121     4.1
@>     TYR119    P      CE1_1805  <--->      LEU89    P      CD2_1326     4.1
@>      ARG40    P        CG_568  <--->      PHE85    P      CE2_1257     4.3
@>      LYS28    P        CG_371  <--->      ILE68    P        CD_983     4.3
@>     PHE138    P      CD2_2108  <--->      ILE21    P        CD_263     4.3
@>     LYS112    P       CG_1690  <--->      TYR87    P      CE1_1283     4.3
@>     TYR131    P      CE1_2006  <--->      ILE16    P        CD_184     4.3
@>      ARG58    P        CG_820  <--->     PHE138    P      CE1_2104     4.5
@> Number of detected hydrophobic interactions: 42.

In [4]: results[:5]
Out[4]: 
[['TYR87', 'OH_1286', 'P', 'ALA156', 'CB_2401', 'P', 3.0459],
 ['MET63', 'CE_894', 'P', 'ALA24', 'CB_298', 'P', 3.3105],
 ['ILE68', 'CG2_976', 'P', 'MET63', 'CE_894', 'P', 3.3306],
 ['TYR142', 'CZ_2171', 'P', 'VAL146', 'CG2_2235', 'P', 3.4815],
 ['ALA22', 'CB_273', 'P', 'PHE10', 'CD1_92', 'P', 3.5334]]
```